### PR TITLE
Add z-index to header

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
         border-collapse: separate;
         position: sticky;
         top: 0;
+	z-index: 1;
       }
 
       #constituencies th {


### PR DESCRIPTION
To fix semi-transparent cells clipping through header in Chrome