### PR TITLE
Remove duplicated "for" in status text

### DIFF
--- a/outputs/index.js
+++ b/outputs/index.js
@@ -95,9 +95,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
                         key = `${show}-${party}`
                         document.getElementById('show-parties').classList.remove('d-none');
                         if (show == 'vote-share') {
-                               rubric.querySelector('#show').textContent = `${party} vote share for`;
+                               rubric.querySelector('#show').textContent = `${party} vote share`;
                         } else {
-                                rubric.querySelector('#show').textContent = `${party} majority for`;
+                                rubric.querySelector('#show').textContent = `${party} majority`;
                         }
                 }
 


### PR DESCRIPTION
I think this might be correct to address the following, but haven't tested it. Feel free to close if this is a bungled fix.

(There could be some other formatting quirks elsewhere that I've not accounted for for.)

![status-text](https://github.com/inglesp/apogee/assets/3818079/bdbe3529-c14f-47fc-b9dd-8bc5b179f84e)